### PR TITLE
時間表示

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -143,6 +143,7 @@ class ContentsController < ApplicationController
         channel_icon: channel_icons[video.snippet.channel_id],
         live_starttime: video.live_streaming_details&.actual_start_time,
         scheduled_starttime: video.live_streaming_details&.scheduled_start_time,
+        archive_duration: video.content_details&.duration,
         live_viewers: video.live_streaming_details&.concurrent_viewers
       }
     end
@@ -158,7 +159,10 @@ class ContentsController < ApplicationController
         .sort_by { |v| v[:scheduled_starttime] }
     when "archive"
       normalized
-        .select { |v| v[:live_starttime].present? }
+        .select do |v|
+          v[:archive_duration].present? &&
+            v[:live_starttime].present?
+        end
         .sort_by { |v| v[:live_starttime] }
         .reverse
     else # live

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,21 @@ module ApplicationHelper
     else "bg-gray-100 text-gray-800"
     end
   end
+
+  def format_duration(iso8601)
+    return "" if iso8601.blank?
+
+    match = iso8601.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/)
+    return "" unless match
+
+    hours   = match[1].to_i
+    minutes = match[2].to_i
+    seconds = match[3].to_i
+
+    if hours > 0
+      format("%d:%02d:%02d", hours, minutes, seconds)
+    else
+      format("%d:%02d", minutes, seconds)
+    end
+  end
 end

--- a/app/services/youtube/channel_videos_fetcher.rb
+++ b/app/services/youtube/channel_videos_fetcher.rb
@@ -56,7 +56,7 @@ module Youtube
 
       @youtube
         .list_videos(
-          "snippet,liveStreamingDetails",
+          "snippet,contentDetails,liveStreamingDetails",
           id: ids.join(",")
         )
         .items

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -18,12 +18,19 @@
         </div>
         <%= link_to "https://www.youtube.com/watch?v=#{video[:video_id]}", class: "block  text-blue-600 visited:text-purple-600 hover:underline", target: "_blank", rel: "noopener noreferrer" do %>
           <!-- 動画サムネイル -->
-          <div class="w-full aspect-[16/9] p-1">
-            <img src="<%= video[:video_thumbnail] %>"
-                 alt="<%= video[:title] %>"
-                 class="w-full h-full rounded object-cover"
-            >
-          </div>
+            <div class="relative overflow-hidden rounded aspect-[16/9]">
+              <img src="<%= video[:video_thumbnail] %>",
+                    alt="<%= video[:title] %>",
+                    class="absolute inset-0 w-full h-full object-cover"
+              >
+              <div class="absolute right-2 bg-black/80 text-white text-xs px-2 py-1 my-2 rounded pointer-events-none"
+                   style="background-color: rgba(0,0,0,0.5);"
+              >
+                <%= format_duration(video[:archive_duration]) %>
+              </div>
+            </div>
+
+
           <!-- 動画タイトル -->
             <p class="px-2 text-sm font-medium line-clamp-2 break-words overflow-hidden"><%= video[:title] %></p>
         <% end %>


### PR DESCRIPTION
## 概要
アーカイブタブにあるものに、動画の全体時間を表示
※ライブは最終的にはyoutubeに遷移するので、配信中ってことだけを知るのが目的なのと経過時間をいれる必要がないと判断したので対応なし

close #66  